### PR TITLE
Updated requestWithBrowser method to support full url

### DIFF
--- a/forceng.js
+++ b/forceng.js
@@ -446,7 +446,6 @@ angular.module('forceng', [])
       function requestWithBrowser(obj) {
         var method = obj.method || 'GET',
           headers = {},
-          url = getRequestBaseURL(),
           deferred = $q.defer();
   
         if(!useProxy && (!oauth || (!oauth.access_token && !oauth.refresh_token))) {
@@ -454,13 +453,18 @@ angular.module('forceng', [])
           return deferred.promise;
         }
   
-        // dev friendly API: Add leading '/' if missing so url + path concat always works
-        if (obj.path.charAt(0) !== '/') {
-          obj.path = '/' + obj.path;
+        if (obj.path.indexOf('https://') === 0) {
+          url = obj.path;
+        } else {
+          
+          // dev friendly API: Add leading '/' if missing so url + path concat always works
+          if (obj.path.charAt(0) !== '/') {
+            obj.path = '/' + obj.path;
+          }
+
+          url = getRequestBaseURL() + obj.path;
         }
-  
-        url = url + obj.path;
-  
+
         if(oauth && oauth.access_token){
            headers["Authorization"] = "Bearer " + oauth.access_token;   
         }
@@ -653,12 +657,14 @@ angular.module('forceng', [])
       } else {
         params = pathOrParams;
 
-        if (params.path.charAt(0) !== "/") {
-          params.path = "/" + params.path;
-        }
+        if (params.path.indexOf('https://') !== 0) {
+          if (params.path.charAt(0) !== "/") {
+            params.path = "/" + params.path;
+          }
 
-        if (params.path.substr(0, 18) !== "/services/apexrest") {
-          params.path = "/services/apexrest" + params.path;
+          if (params.path.substr(0, 18) !== "/services/apexrest") {
+            params.path = "/services/apexrest" + params.path;
+          }
         }
       }
 


### PR DESCRIPTION
Customer issue: https://vlocity.atlassian.net/browse/CARD-2647

There was a critical Salesforce update “Stabilize the Hostname for My Domain URLs in Sandboxes.” This critical update removes instance names from URLs and thus affects all ApexRest calls. 

Forceng constructs the base url of an apexrest call using the url of outh instance. If it is from the cardframework, it is the url of vlocity vf page . However, with the SF update, the apexrest post call (for an unmanaged resource) fails when the url has vlocity namespace in it.  

So either we had to update the getRequestBaseURL() to fetch and use the mydomain url or we had to change the requestWithBrowser() method to skip constructing the base url when it has the full url. We chose latter to minimize the risk.

